### PR TITLE
Changes chain ID to random number.

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -1,6 +1,6 @@
 {
   "config": {
-    "chainId": NETWORK_ID,
+    "chainId": 4173,
     "homesteadBlock": 0,
     "eip150Block": 0,
     "eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",


### PR DESCRIPTION
Same random number (`4173`/`0x104D`) will be used for Parity dev nodes.