### PR TITLE
Field name should be petersburgBlock, not constantinopleFix.

### DIFF
--- a/genesis.json
+++ b/genesis.json
@@ -3,12 +3,11 @@
 		"chainId": 4173,
 		"homesteadBlock": 0,
 		"eip150Block": 0,
-		"eip150Hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
 		"eip155Block": 0,
 		"eip158Block": 0,
 		"byzantiumBlock": 0,
 		"constantinopleBlock": 0,
-		"constantinopleFixBlock": 0,
+		"petersburgBlock": 0,
 		"clique": {
 			"period": 0,
 			"epoch": 30000


### PR DESCRIPTION
Finally received a response from go-ethereum developers.  Also removed the EIP150 hash, since apparently when it is set to 0 it is just ignored anyway.