### PR TITLE
Re-enables unlocked account.

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 exec geth \
+	--allow-insecure-unlock
 	--networkid "$(cat /geth/genesis.json | jq '.config.chainId')" \
 	--datadir "/geth/chain" \
 	--keystore "/geth/keys" \


### PR DESCRIPTION
Recent update made it so unlocked accounts are not allowed when JSON-RPC over HTTP is enabled.

I don't think we actually leverage this anywhere, but I don't feel like dealing with unlocked accounts not working in these test images at the moment so I'm instead re-enabling them.